### PR TITLE
Propar ar plural form

### DIFF
--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -2,6 +2,9 @@
 
 ;(function () {
   var languages = {
+    //In AR, should differnaciate between 1, 2, [3-10] and the rest of the numbers.
+    // see https://github.com/EvanHahn/HumanizeDuration.js/blob/4373d00a97785321088c7a2ebcd1a5b969f3beb0/humanize-duration.js#L157 in the main repo
+
     ar: {
       y: function (c) { return c === 1 ? 'سنة' : 'سنوات' },
       mo: function (c) { return c === 1 ? 'شهر' : 'أشهر' },

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -6,14 +6,14 @@
     // see https://github.com/EvanHahn/HumanizeDuration.js/blob/4373d00a97785321088c7a2ebcd1a5b969f3beb0/humanize-duration.js#L157 in the main repo
 
     ar: {
-      y: function (c) { return c === 1 ? 'سنة' : 'سنوات' },
-      mo: function (c) { return c === 1 ? 'شهر' : 'أشهر' },
-      w: function (c) { return c === 1 ? 'أسبوع' : 'أسابيع' },
-      d: function (c) { return c === 1 ? 'يوم' : 'أيام' },
-      h: function (c) { return c === 1 ? 'ساعة' : 'ساعات' },
-      m: function (c) { return c === 1 ? 'دقيقة' : 'دقائق' },
-      s: function (c) { return c === 1 ? 'ثانية' : 'ثواني' },
-      ms: function (c) { return c === 1 ? 'جزء من الثانية' : 'أجزاء من الثانية' },
+      y: function (c) { return ["سنة", "سنتان", "سنوات"][getArabicForm(c)] },
+      mo: function (c) { return ["شهر", "شهران", "أشهر"][getArabicForm(c)] },
+      w: function (c) { return ["أسبوع", "أسبوعين", "أسابيع"][getArabicForm(c)]},
+      d: function (c) { return ["يوم", "يومين", "أيام"][getArabicForm(c)] },
+      h: function (c) { return ["ساعة", "ساعتين", "ساعات"][getArabicForm(c)] },
+      m: function (c) { return ["دقيقة", "دقيقتان", "دقائق"][getArabicForm(c)] },
+      s: function (c) { return ["ثانية", "ثانيتان", "ثواني"][getArabicForm(c)]; },
+      ms: function (c) { return ["جزء من الثانية", "جزآن من الثانية", "أجزاء من الثانية"][getArabicForm(c)] },
       decimal: ','
     },
     en: {
@@ -193,6 +193,17 @@
     }
     return destination
   }
+
+    function getArabicForm(c) {
+    if (c === 2) {
+      return 1;
+    }
+    if (c > 2 && c < 11) {
+      return 2;
+    }
+    return 0;
+  }
+
 
   humanizeDuration.getSupportedLanguages = function getSupportedLanguages () {
     var result = []


### PR DESCRIPTION
I was recently working on some changes on maple/horizontal FE changes, and I notice that we're using our fork of humanize duration. But it's lacking the proper plural rules for AR as per [language plural rules](https://www.unicode.org/cldr/charts/45/supplemental/language_plural_rules.html#ar), I can also confirm that's correct since it's my own language. : ))

upon further investigation, it turns out that this change was done to original repo, check [getArabicForm function here](https://github.com/EvanHahn/HumanizeDuration.js/blob/4373d00a97785321088c7a2ebcd1a5b969f3beb0/humanize-duration.js#L1482).

This pr is cpying the minimal changes for the proper plural form in AR, it's missing some stuff of things (tests) but I went with this quick and dirty way to see if I should but more time in this.

This is currently in my own fork, I'll either keep it or move depending on the maintainer decision.

So let me know, 